### PR TITLE
Avoid unsetting US as supported region

### DIFF
--- a/PhoneNumberUtil.php
+++ b/PhoneNumberUtil.php
@@ -233,7 +233,13 @@ class PhoneNumberUtil {
 		foreach ($this->countryCallingCodeToRegionCodeMap as $regionCodes) {
 			$this->supportedRegions = array_merge($this->supportedRegions, $regionCodes);
 		}
-		unset($this->supportedRegions[array_search(self::REGION_CODE_FOR_NON_GEO_ENTITY, $this->supportedRegions)]);
+
+		$nonGeoEntityIdx = array_search(self::REGION_CODE_FOR_NON_GEO_ENTITY, $this->supportedRegions);
+		if($nonGeoEntityIdx !== false)
+		{
+			unset($this->supportedRegions[$nonGeoEntityIdx]);
+		}
+
 		$this->nanpaRegions = $this->countryCallingCodeToRegionCodeMap[self::NANPA_COUNTRY_CODE];
 	}
 


### PR DESCRIPTION
The demo.php code, if run for a US phone number with a US region, fails with

```
Error type: 0. Missing or invalid default region.
```

because of the following line in PhoneNumberUtil::init:

``` php
unset($this->supportedRegions[array_search(self::REGION_CODE_FOR_NON_GEO_ENTITY, $this->supportedRegions)]);
```

The array_search returns false, which is coerced to 0 for the unset, which happens to correspond to the US region.

The attached commit prevents this behavior, but I'm not sure what you were trying to do here.  My guess is that you were attempting to check against countryCallingCodeToRegionCodeMap instead of supportedRegions.  If so, feel free to change.  Thanks!  Please let me know if I was misunderstanding something.
